### PR TITLE
Add basic Next.js app with login and dashboard using MUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,56 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import SettingsIcon from '@mui/icons-material/Settings';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import { useState, useContext } from 'react';
+import ThemeContext from '../context/ThemeContext';
+import { useRouter } from 'next/router';
+
+export default function Header() {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const { toggleTheme } = useContext(ThemeContext);
+  const router = useRouter();
+  const open = Boolean(anchorEl);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    handleClose();
+    router.push('/');
+  };
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <div style={{ flexGrow: 1 }}>Dashboard</div>
+        <IconButton color="inherit">
+          <NotificationsIcon />
+        </IconButton>
+        <IconButton color="inherit" onClick={handleMenu}>
+          <SettingsIcon />
+        </IconButton>
+        <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+          <MenuItem onClick={handleClose}>Edit Profile</MenuItem>
+          <MenuItem
+            onClick={() => {
+              toggleTheme();
+              handleClose();
+            }}
+          >
+            Change Theme
+          </MenuItem>
+          <MenuItem onClick={handleLogout}>Logout</MenuItem>
+        </Menu>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/context/ThemeContext.js
+++ b/context/ThemeContext.js
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const ThemeContext = createContext({
+  mode: 'light',
+  toggleTheme: () => {}
+});
+
+export default ThemeContext;

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nextjs-project",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.0",
+    "@mui/material": "^5.15.0",
+    "next": "^13.5.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,22 @@
+import { useState, useMemo } from 'react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import ThemeContext from '../context/ThemeContext';
+
+function MyApp({ Component, pageProps }) {
+  const [mode, setMode] = useState('light');
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  const toggleTheme = () => setMode(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export default MyApp;

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,26 @@
+import Header from '../components/Header';
+import { Grid, Card, CardContent, Typography } from '@mui/material';
+
+export default function Dashboard({ apps }) {
+  return (
+    <>
+      <Header />
+      <Grid container spacing={2} padding={2}>
+        {apps.map((app) => (
+          <Grid item xs={12} sm={6} md={4} key={app}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6">{app}</Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const apps = ['App One', 'App Two', 'App Three'];
+  return { props: { apps } };
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+import { Container, Box, TextField, Button, Typography } from '@mui/material';
+
+export default function Login() {
+  const router = useRouter();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    router.push('/dashboard');
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 8 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Login
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField label="Username" fullWidth margin="normal" required />
+          <TextField label="Password" type="password" fullWidth margin="normal" required />
+          <Button type="submit" variant="contained" fullWidth>
+            Login
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}
+
+export async function getServerSideProps() {
+  return { props: {} };
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js project with Material UI and theme context
- add login page rendered via SSR and dashboard page pre-rendered with SSG
- implement header with notifications and settings menu for profile, theme toggle, and logout

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f62d030ec832ea0d3dd8c76fd9dbc